### PR TITLE
Add  Support for Twig functions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ const defaultOptions = {
   namespaces: {},
   filters: {},
   functions: {},
+  globalContext: {},
   framework: FRAMEWORK_HTML,
   pattern: /\.(twig)(\?.*)?$/,
 }
@@ -193,10 +194,6 @@ const plugin = (options = {}) => {
 
         ${functions}
 
-        addDrupalExtensions(Twig, {
-          active_theme: '${options.activeTheme ?? "default"}'
-        });
-
         // Disable caching.
         Twig.cache(false);
 
@@ -208,7 +205,8 @@ const plugin = (options = {}) => {
           ${includes ? `component.options.allowInlineIncludes = true;` : ""}
           try {
             return frameworkTransform(component.render({
-            attributes: new DrupalAttribute(),
+              attributes: new DrupalAttribute(),
+              ...${JSON.stringify(options.globalContext)},
               ...context
             }));
           }

--- a/src/index.js
+++ b/src/index.js
@@ -111,8 +111,13 @@ const plugin = (options = {}) => {
           frameworkInclude = `import React from 'react'`
           frameworkTransform = `const frameworkTransform = (html) => React.createElement('div', {dangerouslySetInnerHTML: {'__html': html}});;`
         }
-        let embed, embeddedIncludes, functions
-        code, includes, (seen = [])
+        let embed,
+          embeddedIncludes,
+          functions,
+          code,
+          includes,
+          seen = []
+
         try {
           const result = await compileTemplate(id, id, options).catch(
             errorHandler(id)

--- a/tests/__snapshots__/smoke.test.js.snap
+++ b/tests/__snapshots__/smoke.test.js.snap
@@ -1,5 +1,35 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Basic smoke test > Should support global context and functions 1`] = `
+"<section>
+  <h1>Include</h1>
+  <article>
+          Lorem ipsum dolor sit amet, consectetur adipisicing elit. At dignissimos fugiat inventore laborum maiores molestiae neque quia quo unde veniam?
+      </article>
+</section>
+<section>
+  <h1>Embed</h1>
+  <article>
+        Lorem ipsum dolor sit amet.
+    <button class=\\"button--primary\\">Nested include</button>
+          IT WORKS!
+        </article>
+</section>
+<section>
+  <h1></h1>
+  <article>
+          Lorem ipsum dolor sit amet, consectetur adipisicing elit. At dignissimos fugiat inventore laborum maiores molestiae neque quia quo unde veniam?
+      </article>
+</section>
+<section>
+  <h1>Relative include</h1>
+  <article>
+          Lorem ipsum dolor sit amet, consectetur adipisicing elit. At dignissimos fugiat inventore laborum maiores molestiae neque quia quo unde veniam?
+      </article>
+</section>
+"
+`;
+
 exports[`Basic smoke test > Should support includes 1`] = `
 "<section>
   <h1>Include</h1>
@@ -12,7 +42,8 @@ exports[`Basic smoke test > Should support includes 1`] = `
   <article>
         Lorem ipsum dolor sit amet.
     <button class=\\"button--primary\\">Nested include</button>
-    </article>
+          IT WORKS!
+        </article>
 </section>
 <section>
   <h1></h1>
@@ -58,7 +89,8 @@ exports[`Basic smoke test > Should support variables 1`] = `
   <article>
         Lorem ipsum dolor sit amet.
     <button class=\\"button--primary\\">Nested include</button>
-    </article>
+          IT WORKS!
+        </article>
 </section>
 <section>
   <h1>Pickle Fixie</h1>

--- a/tests/fixtures/mockup.twig
+++ b/tests/fixtures/mockup.twig
@@ -3,6 +3,9 @@
   {% block content %}
     Lorem ipsum dolor sit amet.
     {% include "@tests/button.twig" with {text: 'Nested include'} %}
+    {% if active_theme == 'poodles' %}
+      {{ testFunction() }}
+    {% endif %}
   {% endblock %}
 {% endembed %}
 {% include "@tests/section.twig" %}

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -29,4 +29,10 @@ describe("Basic smoke test", () => {
     expect(markup).toContain("Contact")
     expect(markup).toMatchSnapshot()
   })
+  it("Should support global context and functions", () => {
+    const markup = Markup()
+    expect(markup).toMatchSnapshot()
+    expect(markup).toContain("Nested include")
+    expect(markup).toContain("IT WORKS!")
+  })
 })

--- a/vite.config.js
+++ b/vite.config.js
@@ -18,6 +18,13 @@ export default defineConfig({
   },
   plugins: [
     twig({
+      globalContext: {
+        active_theme: "poodles",
+      },
+      functions: {
+        testFunction: (instance) =>
+          instance.extendFunction("testFunction", () => "IT WORKS!"),
+      },
       namespaces: {
         tests: join(__dirname, "/tests/fixtures"),
       },


### PR DESCRIPTION
This fixes #9 , adding support for custom functions. 
Usage gudelines:

Add a `functions` object to the Twig constructor, and pass the custom functions you need into there. Use as normal within Twig templates!

```
import bemTwigExtension from "bem-twig-extension";
```

```
plugins: [
    // Other vite plugins.
    twig({
      namespaces: {
        templates: join(__dirname, "components/templates"),
      },
      functions: {
        bem: bemTwigExtension,
      },
      activeTheme: "zoocha",
     
    })
```

(NB. I also added the ability for passing in the 'active theme' as sometimes I've used that in projects, and it can be helpful)