### PR TITLE
Added normalizePath

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,11 +30,11 @@ const resolveFile = (directory, file) => {
   for (const ix in filesToTry) {
     const path = resolve(filesToTry[ix])
     if (existsSync(path)) {
-      return normalizePath(path);
+      return normalizePath(path)
     }
     const withDir = resolve(directory, filesToTry[ix])
     if (existsSync(withDir)) {
-      return normalizePath(withDir);
+      return normalizePath(withDir)
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import Twig from "twig"
 import { resolve, dirname } from "node:path"
 import { existsSync } from "node:fs"
+import { normalizePath } from "vite"
 
 const { twig } = Twig
 
@@ -26,17 +27,23 @@ const includeTokenTypes = [
 
 const resolveFile = (directory, file) => {
   const filesToTry = [file, `${file}.twig`, `${file}.html.twig`]
+
+  let resolvedFile = ""
+
   for (const ix in filesToTry) {
     const path = resolve(filesToTry[ix])
     if (existsSync(path)) {
-      return path
+      resolvedFile = path
+      break
     }
     const withDir = resolve(directory, filesToTry[ix])
     if (existsSync(withDir)) {
-      return withDir
+      resolvedFile = withDir
+      break
     }
   }
-  return resolve(directory, file)
+
+  return normalizePath(resolvedFile || resolve(directory, file))
 }
 
 const pluckIncludes = (tokens) => {

--- a/src/index.js
+++ b/src/index.js
@@ -27,23 +27,18 @@ const includeTokenTypes = [
 
 const resolveFile = (directory, file) => {
   const filesToTry = [file, `${file}.twig`, `${file}.html.twig`]
-
-  let resolvedFile = ""
-
   for (const ix in filesToTry) {
     const path = resolve(filesToTry[ix])
     if (existsSync(path)) {
-      resolvedFile = path
-      break
+      return normalizePath(path);
     }
     const withDir = resolve(directory, filesToTry[ix])
     if (existsSync(withDir)) {
-      resolvedFile = withDir
-      break
+      return normalizePath(withDir);
     }
   }
 
-  return normalizePath(resolvedFile || resolve(directory, file))
+  return normalizePath(resolve(directory, file))
 }
 
 const pluckIncludes = (tokens) => {


### PR DESCRIPTION
Added normalizePath method from vite so the import part for the templates work on windows machines. Changes e.g. c:\path\to\file.twig => c:/path/to/file.twig

Issue: https://github.com/larowlan/vite-plugin-twig-drupal/issues/24