### PR TITLE
Adding support for Vite 6

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         node: [18, 20]
-        vite: [4, 5, 6]
+        vite: [4, 5, 6, 7]
     runs-on: ubuntu-latest
     steps:
       - name: 🛑 Cancel Previous Runs

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "twig": "^1.16.0"
   },
   "peerDependencies": {
-    "vite": "^4.4.11 || ^5 || ^6"
+    "vite": "^4.4.11 || ^5 || ^6 || ^7"
   },
   "devDependencies": {
     "prettier": "^3.0.3",


### PR DESCRIPTION
- Bumps the vite version constraint to allow ^7
- Adds Vite 7 to the testing matrix

I watched vite migration guide, https://vite.dev/guide/migration.html , they do not touch rollup or something to it. I presume its safe to bump it? 

