### PR TITLE
fix: additional vite 8 ci and build fixes

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -11,6 +11,11 @@ jobs:
       matrix:
         node: [18, 20, 22]
         vite: [4, 5, 6, 7, 8]
+        exclude:
+          - node: 18
+            vite: 7
+          - node: 18
+            vite: 8
     runs-on: ubuntu-latest
     steps:
       - name: 🛑 Cancel Previous Runs

--- a/src/index.js
+++ b/src/index.js
@@ -190,6 +190,7 @@ const plugin = (options = {}) => {
                     dirname(id),
                     resolveNamespaceOrComponent(options.namespaces, template)
                   )
+                  this.addWatchFile(file)
                   if (!(template in seen)) {
                     return compileTemplate(template, file, options)
                       .catch(errorHandler(template, false))

--- a/vite.config.js
+++ b/vite.config.js
@@ -17,6 +17,7 @@ export default defineConfig({
         ),
       },
       name: "vite-plugin-twig-drupal",
+      formats: ["es"],
       fileName: (_, entry) => `${entry}.js`,
     },
   },


### PR DESCRIPTION
This PR includes:

- Ensures ESM output instead of CJS.
- Excludes node < 20 from ci matrix for vite 7 and 8 as they require newer versions.
- Should bring back some of the functionality provided by `shouldTransformCachedModule` using `addWatchFile`.