### PR TITLE
fix(core): skip _self resolution in promisifyIncludes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -186,6 +186,11 @@ const plugin = (options = {}) => {
             return includes.reduce(
               (queue, template) =>
                 queue.then(() => {
+                  // _self is a special Twig variable referring to the current
+                  // template — it is not a real file import.
+                  if (template === "_self") {
+                    return Promise.resolve()
+                  }
                   const file = resolveFile(
                     dirname(id),
                     resolveNamespaceOrComponent(options.namespaces, template)

--- a/tests/__snapshots__/smoke.test.js.snap
+++ b/tests/__snapshots__/smoke.test.js.snap
@@ -134,6 +134,20 @@ exports[`Basic smoke test > Should support global context and functions 1`] = `
 "
 `;
 
+exports[`Basic smoke test > Should support import _self for recursive macros 1`] = `
+"
+
+<nav>
+  <ul>
+      <li><a href=\\"/home\\">Home</a></li>
+
+      <li><a href=\\"/about\\">About</a></li>
+
+  </ul>
+</nav>
+"
+`;
+
 exports[`Basic smoke test > Should support includes 1`] = `
 "<section>
   <h1>Include</h1>

--- a/tests/fixtures/self-import.twig
+++ b/tests/fixtures/self-import.twig
@@ -1,0 +1,12 @@
+{% import _self as nav %}
+
+{% macro menu_link(title, href) %}
+  <li><a href="{{ href }}">{{ title }}</a></li>
+{% endmacro %}
+
+<nav>
+  <ul>
+    {{ nav.menu_link('Home', '/home') }}
+    {{ nav.menu_link('About', '/about') }}
+  </ul>
+</nav>

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -3,6 +3,7 @@ import Error from "../dist/error.js"
 import ErrorInclude from "../dist/errorInclude.js"
 import drupalFunctions from "../dist/drupalFunctions.js"
 import Menu from "../dist/menu.js"
+import SelfImport from "../dist/selfImport.js"
 import { describe, expect, it } from "vitest"
 
 describe("Basic smoke test", () => {
@@ -71,5 +72,11 @@ describe("Basic smoke test", () => {
     const markup = Markup()
     expect(markup).toContain("All received")
     expect(markup).toContain("pony town")
+  })
+  it("Should support import _self for recursive macros", () => {
+    const markup = SelfImport()
+    expect(markup).toContain("Home")
+    expect(markup).toContain("About")
+    expect(markup).toMatchSnapshot()
   })
 })

--- a/vite.config.js
+++ b/vite.config.js
@@ -15,6 +15,7 @@ export default defineConfig({
           __dirname,
           "tests/fixtures/drupal-functions.twig"
         ),
+        selfImport: resolve(__dirname, "tests/fixtures/self-import.twig"),
       },
       name: "vite-plugin-twig-drupal",
       formats: ["es"],


### PR DESCRIPTION
Claude assisted with this PR.

Twig templates using `{% import _self as nav %}` cause a fatal error in Vite 8's dev server (and vitest):

```
Failed to resolve import "/path/to/src/Component/Navigation/_self"
from "src/Component/Navigation/navigation.html.twig". Does the file exist?
```

This happens because `pluckIncludes` extracts `_self` from `{% import _self as nav %}` tokens and passes it through `resolveFile()` and `addWatchFile()` in `promisifyIncludes`. While `_self` is already filtered out from the `embed` imports on [line 214](https://github.com/larowlan/vite-plugin-twig-drupal/blob/ea8b2a12611acff0c5c487d5176c666bc85623c6/src/index.js#L214), it is not skipped during include processing, so it resolves to a non-existent file path like `/path/to/src/Component/Navigation/_self`.

In Vite 8's dev server (used by vitest), `vite:import-analysis` is strict about unresolvable imports, so the generated `import '/path/to/_self'` statement causes a hard error. The build pipeline is more lenient, which is why `vite build` works fine but `vitest` does not.

## Fix

Add an early return in `promisifyIncludes` to skip `_self` before any file resolution is attempted. `_self` is a special Twig variable that refers to the current template — it is not a file import and should never be resolved as one.

## Test

Added a `self-import.twig` test fixture that uses `{% import _self as nav %}` at the top level, along with a corresponding test case that verifies the template compiles and renders correctly.

## Affected templates

Any Twig template using recursive macros via `{% import _self as ... %}`, which is a common Twig pattern for rendering nested structures like navigation menus and tree views.